### PR TITLE
Fix sound example divide by zero

### DIFF
--- a/example/sound/sound.ino
+++ b/example/sound/sound.ino
@@ -46,6 +46,7 @@ void soundCallback(const std_msgs::Byte& sound_msg)
 
   uint16_t note[8]     = {0, 0};
   uint8_t  duration[8] = {0, 0};
+  uint8_t  note_num    = 8;
 
   switch (sound_msg.data)
   {
@@ -98,11 +99,13 @@ void soundCallback(const std_msgs::Byte& sound_msg)
      break;
 
     case 5:
-      sound_name_msg.data = NONE;  
+      sound_name_msg.data = NONE;
+      note_num = 0;
      break;
 
     case 6:
-      sound_name_msg.data = NONE;  
+      sound_name_msg.data = NONE;
+      note_num = 0;
      break;
 
     default:
@@ -119,7 +122,8 @@ void soundCallback(const std_msgs::Byte& sound_msg)
   }
 
   sound_info_pub.publish(&sound_name_msg);
-  melody(note, 8, duration);
+  if (note_num > 0)
+    melody(note, note_num, duration);
 }
 
 


### PR DESCRIPTION
## Summary
- prevent divide by zero error in `sound.ino`

## Testing
- `pytest -q`
- `make test` *(fails: No rule to make target)*


------
https://chatgpt.com/codex/tasks/task_e_68444e6093fc8324a7157fd36d4f727c